### PR TITLE
Removed version translations in splash screen form

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.Designer.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.Designer.vb
@@ -23,7 +23,6 @@ Partial Class frmSplashScreen
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
-        Dim lblWait As System.Windows.Forms.Label
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(frmSplashScreen))
         Me.MainLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
         Me.ApplicationTitle = New System.Windows.Forms.Label()
@@ -127,6 +126,7 @@ Partial Class frmSplashScreen
     Friend WithEvents Timer1 As System.Windows.Forms.Timer
     Friend WithEvents ApplicationTitle As System.Windows.Forms.Label
     Friend WithEvents lblDescription As System.Windows.Forms.Label
-    Public WithEvents MainLayoutPanel As System.Windows.Forms.TableLayoutPanel
+    Friend WithEvents MainLayoutPanel As System.Windows.Forms.TableLayoutPanel
     Friend WithEvents lblVersion As System.Windows.Forms.Label
+    Friend WithEvents lblWait As System.Windows.Forms.Label
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.Designer.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.Designer.vb
@@ -24,7 +24,6 @@ Partial Class frmSplashScreen
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(frmSplashScreen))
-
         Me.MainLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
         Me.lblDescription = New System.Windows.Forms.Label()
         Me.ApplicationTitle = New System.Windows.Forms.Label()
@@ -60,11 +59,12 @@ Partial Class frmSplashScreen
         'lblWait
         '
         Me.lblWait.Anchor = System.Windows.Forms.AnchorStyles.None
+        Me.lblWait.AutoSize = True
         Me.lblWait.BackColor = System.Drawing.Color.Transparent
         Me.lblWait.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.lblWait.Location = New System.Drawing.Point(432, 460)
+        Me.lblWait.Location = New System.Drawing.Point(442, 462)
         Me.lblWait.Name = "lblWait"
-        Me.lblWait.Size = New System.Drawing.Size(122, 19)
+        Me.lblWait.Size = New System.Drawing.Size(102, 15)
         Me.lblWait.TabIndex = 8
         Me.lblWait.Tag = "Please_Wait"
         Me.lblWait.Text = "Please Wait.........."
@@ -74,9 +74,9 @@ Partial Class frmSplashScreen
         Me.lblDescription.Anchor = System.Windows.Forms.AnchorStyles.None
         Me.lblDescription.BackColor = System.Drawing.Color.Transparent
         Me.lblDescription.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.lblDescription.Location = New System.Drawing.Point(350, 210)
+        Me.lblDescription.Location = New System.Drawing.Point(182, 210)
         Me.lblDescription.Name = "lblDescription"
-        Me.lblDescription.Size = New System.Drawing.Size(286, 20)
+        Me.lblDescription.Size = New System.Drawing.Size(621, 20)
         Me.lblDescription.TabIndex = 1
         Me.lblDescription.Tag = "Climate_Data_Management_System"
         Me.lblDescription.Text = "Climate Data Management System"
@@ -97,11 +97,12 @@ Partial Class frmSplashScreen
         'lblVersion
         '
         Me.lblVersion.Anchor = System.Windows.Forms.AnchorStyles.None
+        Me.lblVersion.AutoSize = True
         Me.lblVersion.BackColor = System.Drawing.Color.Transparent
         Me.lblVersion.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.lblVersion.Location = New System.Drawing.Point(443, 289)
+        Me.lblVersion.Location = New System.Drawing.Point(469, 295)
         Me.lblVersion.Name = "lblVersion"
-        Me.lblVersion.Size = New System.Drawing.Size(99, 27)
+        Me.lblVersion.Size = New System.Drawing.Size(48, 15)
         Me.lblVersion.TabIndex = 6
         Me.lblVersion.Text = "Version"
         '
@@ -122,6 +123,7 @@ Partial Class frmSplashScreen
         Me.ShowInTaskbar = False
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
         Me.MainLayoutPanel.ResumeLayout(False)
+        Me.MainLayoutPanel.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub

--- a/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.Designer.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.Designer.vb
@@ -24,26 +24,15 @@ Partial Class frmSplashScreen
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(frmSplashScreen))
+
         Me.MainLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
+        Me.lblDescription = New System.Windows.Forms.Label()
         Me.ApplicationTitle = New System.Windows.Forms.Label()
         Me.lblVersion = New System.Windows.Forms.Label()
         Me.Timer1 = New System.Windows.Forms.Timer(Me.components)
-        Me.lblDescription = New System.Windows.Forms.Label()
-        lblWait = New System.Windows.Forms.Label()
+        Me.lblWait = New System.Windows.Forms.Label()
         Me.MainLayoutPanel.SuspendLayout()
         Me.SuspendLayout()
-        '
-        'lblWait
-        '
-        lblWait.Anchor = System.Windows.Forms.AnchorStyles.None
-        lblWait.BackColor = System.Drawing.Color.Transparent
-        lblWait.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        lblWait.Location = New System.Drawing.Point(432, 460)
-        lblWait.Name = "lblWait"
-        lblWait.Size = New System.Drawing.Size(122, 19)
-        lblWait.TabIndex = 7
-        lblWait.Tag = "Please_Wait"
-        lblWait.Text = "Please Wait.........."
         '
         'MainLayoutPanel
         '
@@ -52,9 +41,9 @@ Partial Class frmSplashScreen
         Me.MainLayoutPanel.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
         Me.MainLayoutPanel.ColumnCount = 1
         Me.MainLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 986.0!))
+        Me.MainLayoutPanel.Controls.Add(lblWait, 0, 3)
         Me.MainLayoutPanel.Controls.Add(Me.lblDescription, 0, 1)
         Me.MainLayoutPanel.Controls.Add(Me.ApplicationTitle, 1, 0)
-        Me.MainLayoutPanel.Controls.Add(lblWait, 0, 3)
         Me.MainLayoutPanel.Controls.Add(Me.lblVersion, 0, 2)
         Me.MainLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill
         Me.MainLayoutPanel.Location = New System.Drawing.Point(0, 0)
@@ -64,8 +53,34 @@ Partial Class frmSplashScreen
         Me.MainLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 105.0!))
         Me.MainLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 59.0!))
         Me.MainLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
+        Me.MainLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
         Me.MainLayoutPanel.Size = New System.Drawing.Size(983, 607)
         Me.MainLayoutPanel.TabIndex = 0
+        '
+        'lblWait
+        '
+        Me.lblWait.Anchor = System.Windows.Forms.AnchorStyles.None
+        Me.lblWait.BackColor = System.Drawing.Color.Transparent
+        Me.lblWait.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblWait.Location = New System.Drawing.Point(432, 460)
+        Me.lblWait.Name = "lblWait"
+        Me.lblWait.Size = New System.Drawing.Size(122, 19)
+        Me.lblWait.TabIndex = 8
+        Me.lblWait.Tag = "Please_Wait"
+        Me.lblWait.Text = "Please Wait.........."
+        '
+        'lblDescription
+        '
+        Me.lblDescription.Anchor = System.Windows.Forms.AnchorStyles.None
+        Me.lblDescription.BackColor = System.Drawing.Color.Transparent
+        Me.lblDescription.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblDescription.Location = New System.Drawing.Point(350, 210)
+        Me.lblDescription.Name = "lblDescription"
+        Me.lblDescription.Size = New System.Drawing.Size(286, 20)
+        Me.lblDescription.TabIndex = 1
+        Me.lblDescription.Tag = "Climate_Data_Management_System"
+        Me.lblDescription.Text = "Climate Data Management System"
+        Me.lblDescription.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'ApplicationTitle
         '
@@ -88,23 +103,10 @@ Partial Class frmSplashScreen
         Me.lblVersion.Name = "lblVersion"
         Me.lblVersion.Size = New System.Drawing.Size(99, 27)
         Me.lblVersion.TabIndex = 6
-        Me.lblVersion.Text = "Version 4.1.12"
+        Me.lblVersion.Text = "Version"
         '
         'Timer1
         '
-        '
-        'lblDescription
-        '
-        Me.lblDescription.Anchor = System.Windows.Forms.AnchorStyles.None
-        Me.lblDescription.BackColor = System.Drawing.Color.Transparent
-        Me.lblDescription.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.lblDescription.Location = New System.Drawing.Point(350, 210)
-        Me.lblDescription.Name = "lblDescription"
-        Me.lblDescription.Size = New System.Drawing.Size(286, 20)
-        Me.lblDescription.TabIndex = 1
-        Me.lblDescription.Tag = "Climate_Data_Management_System"
-        Me.lblDescription.Text = "Climate Data Management System"
-        Me.lblDescription.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'frmSplashScreen
         '

--- a/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.resx
+++ b/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="lblWait.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="MainLayoutPanel.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -17101,6 +17098,9 @@
         AABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="lblWait.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <metadata name="Timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmSplashScreen.vb
@@ -14,9 +14,6 @@
 ' You should have received a copy of the GNU General Public License
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Imports ClimsoftVer4.Translations
-
-
 Public NotInheritable Class frmSplashScreen
     Public DelayPeriod As Integer = 0
 
@@ -45,6 +42,8 @@ Public NotInheritable Class frmSplashScreen
         End If
 
         ClsTranslations.TranslateForm(Me)
+        'due to translations. Append the version number here
+        lblVersion.Text = lblVersion.Text & " 4.2.0"
 
         Timer1.Start()
 
@@ -73,4 +72,6 @@ Public NotInheritable Class frmSplashScreen
         End If
 
     End Sub
+
+
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/translations/translate_ignore.txt
+++ b/ClimsoftVer4/ClimsoftVer4/translations/translate_ignore.txt
@@ -75,6 +75,10 @@
 # Navigation buttons contain symbols only, should not be translated
 %_btnMove%
 
+# In the 'SplashScreen' form, the followingshould not be translated
+frmSplashScreen_MainLayoutPanel_lblVersion
+frmSplashScreen_MainLayoutPanel_ApplicationTitle
+
 # In the 'Login' form, the language label should not be translated
 frmLogin_lblLanguage
 


### PR DESCRIPTION
@mhabimana this is now ready for you.
This should make the version and application title label not to be translated.